### PR TITLE
Fix GET issue

### DIFF
--- a/api_definition/coepi_api_0.3.0.yml
+++ b/api_definition/coepi_api_0.3.0.yml
@@ -77,7 +77,7 @@ paths:
       x-amazon-apigateway-integration:
         type: aws_proxy
         uri: ${lambda_invoke_arn}
-        httpMethod: GET
+        httpMethod: POST
 
       responses:
         '200':

--- a/terraform/apigateway.tf
+++ b/terraform/apigateway.tf
@@ -4,8 +4,6 @@ data "template_file" "coepi_api_swagger" {
   # #Pass the varible value if needed in swagger file
   vars = {
    lambda_invoke_arn = aws_lambda_function.coepi_lambda.invoke_arn
-   # lambda_invoke_role           = "${var.type}"
-   # backend_uri   = "https://api.endpoint.url"
   }
 }
 


### PR DESCRIPTION
GET call was failing - I missed that while the call _coming into_ the API Gateway is a GET - the call GOING TO the Lambda must always be POST - because that's how Lambdas work.
