### PR TITLE
Smooth onboarding for Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 .gradle*
 .swagger-codegen*
 Dockerfile*
-.terraform
-*.tfstate*
 /build/
+
+# Terraform
+
+*.tfstate*
+.terraform
+terraform/backend.local
+

--- a/README.md
+++ b/README.md
@@ -18,10 +18,14 @@ Requirements:
 
 All infrastructure concerns are managed by [Terraform](https://terraform.io/) (v0.12+). You can either download Terraform from their site, or install it with [Choco](https://chocolatey.org/) (Windows), [brew](https://brew.sh) (macOS), or your Linux distribution's package manager.
 
-Next you will want to create an S3 bucket to store your Terraform [remote state](https://www.terraform.io/docs/backends/index.html). This will need to be uniquely named, and should be private and encrypted. A script has been provided to do this for you:
+Terraform tracks the [state of your infrastructure](https://www.terraform.io/docs/state/index.html) in a `tfstate` file, which can be stored either locally or remotely. While we recommend remote state, both options are documented here for convenience.
 
-```shell
-TFSTATE_BUCKET=<your bucket name here> ./scripts/terraform_setup.sh
+#### Option 1: Remote Terraform State (Recommended)
+
+First, create an S3 bucket to store your Terraform [remote state](https://www.terraform.io/docs/backends/index.html). This will need to be uniquely named, and should be private and encrypted. A script has been provided to do this for you:
+
+```shell script
+TFSTATE_BUCKET=your_bucket_name_here ./scripts/terraform_setup.sh
 ```
 
 (If you're not sure what to name your bucket, try something like `<your github username>-tcn-infra`.)
@@ -36,8 +40,16 @@ _(The `backend.local` file is specific to your development environment and is ig
 
 Finally, initialize your Terraform project:
 
-```shell
+```shell script
 terraform init -backend-config=backend.local
+```
+
+#### Option 2: Local Terraform State
+
+In a terminal, navigate to `./terraform` and run the following to initialize your Terraform state:
+
+```shell script
+terraform init
 ```
 
 ## Build

--- a/scripts/terraform_setup.sh
+++ b/scripts/terraform_setup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+aws s3api create-bucket \
+  --bucket $TFSTATE_BUCKET \
+  --region us-east-1 \
+  --acl private
+
+aws s3api put-bucket-encryption \
+  --bucket $TFSTATE_BUCKET \
+  --server-side-encryption-configuration '{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'

--- a/terraform/backend.local.example
+++ b/terraform/backend.local.example
@@ -1,0 +1,5 @@
+# Copy this file to `backend.local` and update with the S3 bucket name you're using to store
+# Terraform state
+
+bucket = "tf-coepi-backend-bucket"
+region = "us-east-1"

--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -3,12 +3,10 @@ terraform {
   required_providers {
     aws = ">= 2.56.0"
     template = "~> 2.1"
-
   }
 
   backend "s3" {
-    bucket = "tf-coepi-backend-bucket"
-    key    = "prd/tfstate"
+    key = "prd/tfstate"
   }
 }
 


### PR DESCRIPTION
_[Was getting set up this afternoon and ran into a couple bumps in the road. Hopefully this PR will help smooth those out for future contributors.]_

Updates the Terraform usage and documentation to simplify onboarding.

- Provide a script to create a private, encrypted S3 bucket for storing
  Terraform state
- Use a config file to specify backend configuration so that devs can
  specify their bucket name once in a gitignored config file.
- Update README to describe how to use the script and the backend
  config. Separate out infrastructure setup documentation from the main
  build-and-deploy loop documentation.